### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/js/page.js
+++ b/js/page.js
@@ -1,8 +1,20 @@
 $('#small-nav-dropdown').change(function () {
-  window.location = $(this)
+  const selectedValue = $(this)
     .find('option:selected')
-    .val()
-})
+    .val();
+  if (selectedValue && isValidUrl(selectedValue)) {
+    window.location = selectedValue;
+  }
+});
+
+function isValidUrl(url) {
+  try {
+    const parsedUrl = new URL(url, window.location.origin);
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+  } catch (e) {
+    return false;
+  }
+}
 
 const site_tag = 'UA-62780441-30';
 function loadAnalytics(gtag) {


### PR DESCRIPTION
Potential fix for [https://github.com/davidanderson01/language-server-protocol/security/code-scanning/1](https://github.com/davidanderson01/language-server-protocol/security/code-scanning/1)

To fix the issue, we need to ensure that the value retrieved from the dropdown is sanitized and validated before being used. Specifically, we should check that the value is a valid URL and does not contain any malicious content. A simple way to achieve this is to use a regular expression or a URL parser to validate the value before assigning it to `window.location`.

The fix involves:
1. Extracting the value from the dropdown as before.
2. Validating the value to ensure it is a safe and valid URL.
3. Only assigning the value to `window.location` if it passes validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
